### PR TITLE
re-designed subject search to be within the subject graph

### DIFF
--- a/apps/web/src/components/common/inputs/search-input.tsx
+++ b/apps/web/src/components/common/inputs/search-input.tsx
@@ -9,6 +9,7 @@ export interface SearchInputProps {
   label?: ReactNode;
   emptyDisplay?: ReactNode;
   className?: string;
+  placeholder?: string;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onSelect?: (selection: string) => void;
 }
@@ -24,7 +25,7 @@ export default function SearchInput(props: SearchInputProps) {
       type="text"
       tabIndex={0}
       className={classNames("input input-bordered w-full", props.className)}
-      placeholder={"Search..."}
+      placeholder={props.placeholder || "Search..."}
       onKeyDown={keyDownHandler}
       value={props.value}
       onChange={onChangeHandler}
@@ -43,12 +44,12 @@ export default function SearchInput(props: SearchInputProps) {
       )}
       <ul
         tabIndex={0}
-        className="absolute mt-2 p-2 shadow menu menu-compact dropdown-content bg-base-300 rounded-box w-full max-h-48 overflow-y-auto flex-nowrap"
+        className="absolute mt-2 p-2 shadow menu menu-compact dropdown-content bg-base-300 rounded-lg  w-full max-h-48 overflow-y-auto flex-nowrap"
       >
         {filteredSelections.length == 0 ? (
           <li>
             <a>
-              <InformationCircleIcon className={"w-5"} /> No selection found!
+              <InformationCircleIcon className={"w-5"} /> Type to search!
             </a>
           </li>
         ) : (

--- a/apps/web/src/components/graph-search.tsx
+++ b/apps/web/src/components/graph-search.tsx
@@ -1,0 +1,46 @@
+import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
+import { useState } from "react";
+import SearchInput from "./common/inputs/search-input";
+
+export interface GraphSearchProps {
+  selections?: string[];
+  onSelect?: (selection: string) => void;
+}
+
+export default function GraphSearch(props: GraphSearchProps) {
+  const [opened, setOpened] = useState(false);
+  const [selection, setSelection] = useState("");
+
+  return (
+    <div>
+      {opened ? (
+        <button
+          className="btn btn-circle btn-sm btn-ghost"
+          onClick={() => setOpened(!opened)}
+        >
+          <MagnifyingGlassIcon className="w-5 h-5" />
+        </button>
+      ) : (
+        <div className="input-group">
+          <SearchInput
+            value={selection}
+            className="input-sm"
+            selections={props.selections}
+            placeholder="Search subject..."
+            onSelect={(selection) => {
+              setSelection(selection);
+              props.onSelect?.(selection);
+            }}
+            onChange={(e) => setSelection(e.target.value)}
+          />
+          <button
+            className="btn btn-circle btn-sm"
+            onClick={() => setOpened(!opened)}
+          >
+            <MagnifyingGlassIcon className="w-5 h-5" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/nav-bar.tsx
+++ b/apps/web/src/components/nav-bar.tsx
@@ -28,7 +28,7 @@ export default function NavBar({
           </Link>
         </h1>
         <div className="flex-1">
-          <div className="w-2/3 mx-auto">
+          {/* <div className="w-2/3 mx-auto">
             <SearchInput
               label={<MagnifyingGlassIcon className="w-5 h-5" />}
               className="input-sm"
@@ -40,7 +40,7 @@ export default function NavBar({
                 onSearch?.(subj);
               }}
             />
-          </div>
+          </div> */}
         </div>
         {status == "unauthenticated" ? <LoginBar /> : <NavigationOptions />}
       </div>

--- a/apps/web/src/components/subject-graph.tsx
+++ b/apps/web/src/components/subject-graph.tsx
@@ -1,5 +1,4 @@
 import { LinkIcon, TrashIcon } from "@heroicons/react/24/outline";
-import { VaultSubject } from "@prisma/client";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 import ForceGraph2D, {
@@ -10,24 +9,26 @@ import ForceGraph2D, {
 import { Point } from "../types/geometry";
 import { trpc } from "../utils/trpc";
 import ContextMenu from "./common/context-menu";
+import LoadingDisplay from "./common/loading-display";
+import GraphSearch from "./graph-search";
 
 export interface SubjectGraphProps {
   width: number;
   height: number;
-  subjectData?: Record<
-    string,
-    VaultSubject & {
-      parents: string[];
-      children: string[];
-    }
-  >;
-  subjectFocus?: string;
 }
+
+//Replace NodeObjects with this new type and remove use of any
+type SubjectNode = NodeObject & {
+  id: string;
+  label: string;
+  val: number;
+};
 
 export default function SubjectGraph(props: SubjectGraphProps) {
   const router = useRouter();
   const forceGraph = useRef<ForceGraphMethods>();
 
+  const { data: subjectData } = trpc.useQuery(["vault.subjectGraph"]);
   const addRelationship = trpc.useMutation(["vault.addRelationship"]);
   const removeRelationship = trpc.useMutation(["vault.removeRelationship"]);
 
@@ -41,135 +42,154 @@ export default function SubjectGraph(props: SubjectGraphProps) {
   const ctxNode = useRef("");
   const ctxLink = useRef<LinkObject>();
 
+  const sortedSubjectNames =
+    subjectData != undefined
+      ? Object.values(subjectData)
+          .map((s) => s.name)
+          .sort((s1, s2) => (s1 < s2 ? -1 : 1))
+      : [];
+
   useEffect(() => {
     const graphData = parseForceGraphData();
     if (graphData) setGraphData(graphData);
-  }, [props.subjectData]);
-
-  useEffect(() => {
-    if (!props.subjectFocus) return;
-
-    const searchedNode = graphData?.nodes?.find(
-      (n: any) => n.label == props.subjectFocus
-    );
-    //add 30 to account for navbar
-    forceGraph.current?.centerAt(
-      searchedNode?.x,
-      (searchedNode?.y ?? 0) + 30,
-      500
-    );
-    forceGraph.current?.zoom(3, 500);
-  }, [props.subjectFocus]);
+  }, [subjectData]);
 
   return (
     <>
-      <ForceGraph2D
-        ref={forceGraph}
-        graphData={graphData}
-        nodeColor={(n) => (targetNode == n.id ? "gold" : "#505050")}
-        linkWidth={2}
-        linkDirectionalArrowLength={3}
-        linkDirectionalArrowRelPos={1}
-        nodeCanvasObjectMode={() => "after"}
-        nodeCanvasObject={(node: any, ctx) => {
-          const fontSize = 8;
-          ctx.font = `${fontSize}px Sans-Serif`;
-          ctx.textAlign = "center";
-          ctx.textBaseline = "middle";
-          ctx.fillStyle = "black";
-          ctx.fillText(node.label, node.x, node.y! + 12);
-        }}
-        onNodeClick={(node: any) => {
-          if (targetNode) {
-            if (targetNode != node.id) {
-              addRelationship.mutateAsync({
-                parent: targetNode,
-                child: node.id,
-              });
-              setGraphData({
-                nodes: graphData?.nodes ?? [],
-                links: [
-                  ...(graphData?.links ?? []),
-                  { source: targetNode, target: node.id },
-                ],
-              });
-            }
-            setTargetNode("");
-          } else router.push("/vault/" + node["label"].toLowerCase());
-        }}
-        onNodeRightClick={(node: any, e: MouseEvent) => {
-          e.preventDefault();
-          setContextMenuPos({ x: e.clientX, y: e.clientY });
-          ctxNode.current = node.id;
-        }}
-        onLinkRightClick={(link, e) => {
-          setLinkMenuPos({ x: e.clientX, y: e.clientY });
-          ctxLink.current = link;
-        }}
-        onBackgroundClick={(e) => {
-          setContextMenuPos(undefined);
-          setLinkMenuPos(undefined);
-        }}
-      />
-      {/* Link menu */}
-      <ContextMenu position={linkMenuPos}>
-        <li>
-          <a
-            className="rounded"
-            onClick={(_) => {
-              const link = ctxLink.current;
-              // i mighta crossed the names here
-              removeRelationship.mutateAsync({
-                parent: ((link?.source as NodeObject).id as string) ?? "",
-                child: ((link?.target as NodeObject).id as string) ?? "",
-              });
-              console.log(link);
-              setGraphData({
-                nodes: graphData?.nodes ?? [],
-                links:
-                  graphData?.links?.filter(
-                    (l) => l.source != link?.source || l.target != link?.target
-                  ) ?? [],
-              });
-              setLinkMenuPos(undefined);
-              ctxLink.current = undefined;
+      {subjectData == undefined ? (
+        <div className={"mt-24"}>
+          <LoadingDisplay />
+        </div>
+      ) : (
+        <>
+          <div className="absolute p-3 z-10 right-0">
+            <GraphSearch
+              selections={sortedSubjectNames}
+              onSelect={(selection) => {
+                const searchedNode = graphData?.nodes?.find(
+                  (n: any) => n.label == selection
+                );
+                //add 30 to account for navbar
+                forceGraph.current?.centerAt(
+                  searchedNode?.x,
+                  (searchedNode?.y ?? 0) + 30,
+                  500
+                );
+                forceGraph.current?.zoom(3, 500);
+              }}
+            />
+          </div>
+          <ForceGraph2D
+            ref={forceGraph}
+            width={props.width}
+            height={props.height}
+            graphData={graphData}
+            nodeColor={(n) => (targetNode == n.id ? "gold" : "#505050")}
+            linkWidth={2}
+            linkDirectionalArrowLength={3}
+            linkDirectionalArrowRelPos={1}
+            nodeCanvasObjectMode={() => "after"}
+            nodeCanvasObject={(node: any, ctx) => {
+              const fontSize = 8;
+              ctx.font = `${fontSize}px Sans-Serif`;
+              ctx.textAlign = "center";
+              ctx.textBaseline = "middle";
+              ctx.fillStyle = "black";
+              ctx.fillText(node.label, node.x, node.y! + 12);
             }}
-          >
-            Disconnect
-          </a>
-        </li>
-      </ContextMenu>
-      {/* Subject Menu */}
-      <ContextMenu
-        position={contextMenuPos}
-        onClose={() => setContextMenuPos(undefined)}
-      >
-        <li>
-          <a
-            className={"rounded"}
-            onClick={(_) => {
-              setTargetNode(ctxNode.current);
+            onNodeClick={(node: any) => {
+              if (targetNode) {
+                if (targetNode != node.id) {
+                  addRelationship.mutateAsync({
+                    parent: targetNode,
+                    child: node.id,
+                  });
+                  setGraphData({
+                    nodes: graphData?.nodes ?? [],
+                    links: [
+                      ...(graphData?.links ?? []),
+                      { source: targetNode, target: node.id },
+                    ],
+                  });
+                }
+                setTargetNode("");
+              } else router.push("/vault/" + node["label"].toLowerCase());
+            }}
+            onNodeRightClick={(node: any, e: MouseEvent) => {
+              e.preventDefault();
+              setContextMenuPos({ x: e.clientX, y: e.clientY });
+              ctxNode.current = node.id;
+            }}
+            onLinkRightClick={(link, e) => {
+              setLinkMenuPos({ x: e.clientX, y: e.clientY });
+              ctxLink.current = link;
+            }}
+            onBackgroundClick={(e) => {
               setContextMenuPos(undefined);
-              ctxNode.current = "";
+              setLinkMenuPos(undefined);
             }}
+          />
+          {/* Link menu */}
+          <ContextMenu position={linkMenuPos}>
+            <li>
+              <a
+                className="rounded"
+                onClick={(_) => {
+                  const link = ctxLink.current;
+                  // i mighta crossed the names here
+                  removeRelationship.mutateAsync({
+                    parent: ((link?.source as NodeObject).id as string) ?? "",
+                    child: ((link?.target as NodeObject).id as string) ?? "",
+                  });
+                  setGraphData({
+                    nodes: graphData?.nodes ?? [],
+                    links:
+                      graphData?.links?.filter(
+                        (l) =>
+                          l.source != link?.source || l.target != link?.target
+                      ) ?? [],
+                  });
+                  setLinkMenuPos(undefined);
+                  ctxLink.current = undefined;
+                }}
+              >
+                Disconnect
+              </a>
+            </li>
+          </ContextMenu>
+          {/* Subject Menu */}
+          <ContextMenu
+            position={contextMenuPos}
+            onClose={() => setContextMenuPos(undefined)}
           >
-            <LinkIcon className={"w-5"} />
-            Connect
-          </a>
-        </li>
-        <li>
-          <a className={"rounded hover:bg-error"} onClick={(_) => {}}>
-            <TrashIcon className={"w-5"} />
-            Delete
-          </a>
-        </li>
-      </ContextMenu>
+            <li>
+              <a
+                className={"rounded"}
+                onClick={(_) => {
+                  setTargetNode(ctxNode.current);
+                  setContextMenuPos(undefined);
+                  ctxNode.current = "";
+                }}
+              >
+                <LinkIcon className={"w-5"} />
+                Connect
+              </a>
+            </li>
+            <li>
+              <a className={"rounded hover:bg-error"} onClick={(_) => {}}>
+                <TrashIcon className={"w-5"} />
+                Delete
+              </a>
+            </li>
+          </ContextMenu>
+        </>
+      )}
     </>
   );
 
   function parseForceGraphData() {
     const BASE_SIZE = 3;
-    const subjectGraph = props.subjectData;
+    const subjectGraph = subjectData;
 
     if (!subjectGraph) {
       return;

--- a/apps/web/src/pages/vault/index.tsx
+++ b/apps/web/src/pages/vault/index.tsx
@@ -1,26 +1,14 @@
 import Head from "next/head";
-import React, { useState } from "react";
+import React from "react";
 
-import LoadingDisplay from "../../components/common/loading-display";
 import NavBar from "../../components/nav-bar";
 import SubjectGraph from "../../components/subject-graph-wrapper";
 import { useElementResize } from "../../hooks/element-resize";
 import getAuthServerSideProps from "../../server/common/get-auth-server-side-props";
-import { trpc } from "../../utils/trpc";
 
 export default function Vault() {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const containerSize = useElementResize(containerRef);
-
-  const { data: subjectData } = trpc.useQuery(["vault.subjectGraph"]);
-  const [searchedSubject, setSearchedSubject] = useState("");
-
-  const sortedSubjectNames =
-    subjectData != undefined
-      ? Object.values(subjectData)
-          .map((s) => s.name)
-          .sort((s1, s2) => (s1 < s2 ? -1 : 1))
-      : [];
 
   return (
     <>
@@ -29,20 +17,13 @@ export default function Vault() {
         <link rel="icon" href="/icons/favicon.ico" />
       </Head>
       <main className={"w-screen h-screen flex flex-col"}>
-        <NavBar subjects={sortedSubjectNames} onSearch={setSearchedSubject} />
+        <NavBar />
         <div className={"relative flex-1 w-full"}>
           <div ref={containerRef} className="absolute w-full h-full" />
           <div className="absolute w-full h-full overflow-hidden">
-            {subjectData == undefined && (
-              <div className={"mt-24"}>
-                <LoadingDisplay />
-              </div>
-            )}
             <SubjectGraph
               width={containerSize.width - 1}
               height={containerSize.height - 1}
-              subjectData={subjectData}
-              subjectFocus={searchedSubject}
             />
           </div>
         </div>


### PR DESCRIPTION
Closes #14 

Originally subject search was in the navbar but moved it inside subject-graph for it to be more intuitive. Navbar search will be used for a global search of your vault. Things like going directly to a subject or resource. 